### PR TITLE
Rails 8.0 dummy support

### DIFF
--- a/graphql_devise.gemspec
+++ b/graphql_devise.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'devise_token_auth', '>= 0.1.43', '< 2.0'
   spec.add_dependency 'graphql', '>= 1.8', '< 2.5'
-  spec.add_dependency 'rails', '>= 6.0', '< 7.3'
+  spec.add_dependency 'rails', '>= 6.0', '< 8.1'
   spec.add_dependency 'zeitwerk'
 
   spec.add_development_dependency 'appraisal'


### PR DESCRIPTION
## 変更内容

brooklyn_web の Rails 8.0 対応を行う際、 graphql_devise が Rails 8.0 に対応していないため、アップグレードが止まってしまっていた。

[他に同様の対応をしている人がいた](https://github.com/tmanhkha/graphql_devise/commit/926d5d0285fe7dee8ca036f3013fa460b4106375)ため、こちらを参考に暫定的な対応を行った。

## 確認方法

- [x] [brooklyn_web の Rails 8.0 対応](https://github.com/bloomo-inv/brooklyn-web/pull/2376)でCIが通ることを確認。

## 画面の変更点

なし

## TODO

なし

## その他・レビュアーへ

<!-- その他、レビュアーに伝えることがあれば記載する -->
